### PR TITLE
Fixed file path inside _wp_attachment_metadata

### DIFF
--- a/functions/attachment.php
+++ b/functions/attachment.php
@@ -128,7 +128,7 @@ function bodhi_svgs_generate_svg_attachment_metadata( $metadata, $attachment_id 
 		$metadata = array(
 			'width'		=> intval($dimensions->width),
 			'height'	=> intval($dimensions->height),
-			'file'		=> $filename
+			'file'		=> $relative_path
 		);
 
 		$height = intval($dimensions->height);


### PR DESCRIPTION
Hi there, this is Diego from the WPML Compatibility Team.

I think I found a bug with the metadata generated by `bodhi_svgs_generate_svg_attachment_metadata()`. It's related to this: https://wordpress.org/support/topic/issue-with-wpml-media-translator/

## Steps to Reproduce
- Setup a WP Website + SVG Support plugin
- Upload a regular image and a SVG image to Media > Library
- On `wp_postmeta` in the database, check for the `_wp_attachment_metadata` values of the images
 - The regular image will have something like this. Note the file path there (`2024/12/image-291382.jpeg`):
```php
a:6:{s:5:"width";i:848;s:6:"height";i:821;s:4:"file";s:25:"2024/12/image-291382.jpeg";s:8:"filesize";i:87293;s:5:"sizes";a:3:{s:6:"medium";a:5:{s:4:"file";s:25:"image-291382-300x290.jpeg";s:5:"width";i:300;s:6:"height";i:290;s:9:"mime-type";s:10:"image/jpeg";s:8:"filesize";i:21516;}s:9:"thumbnail";a:5:{s:4:"file";s:25:"image-291382-150x150.jpeg";s:5:"width";i:150;s:6:"height";i:150;s:9:"mime-type";s:10:"image/jpeg";s:8:"filesize";i:7396;}s:12:"medium_large";a:5:{s:4:"file";s:25:"image-291382-768x744.jpeg";s:5:"width";i:768;s:6:"height";i:744;s:9:"mime-type";s:10:"image/jpeg";s:8:"filesize";i:91664;}}s:10:"image_meta";a:12:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";s:11:"orientation";s:1:"0";s:8:"keywords";a:0:{}}}
```
- But for the SVG image, the filepath is missing (`humberger-svgrepo-com.svg`):
```php
a:4:{s:5:"width";i:800;s:6:"height";i:800;s:4:"file";s:25:"humberger-svgrepo-com.svg";s:5:"sizes";a:7:{s:9:"thumbnail";a:5:{s:5:"width";s:3:"150";s:6:"height";d:150;s:4:"crop";b:0;s:4:"file";s:25:"humberger-svgrepo-com.svg";s:9:"mime-type";s:13:"image/svg+xml";}s:6:"medium";a:5:{s:5:"width";s:3:"300";s:6:"height";d:300;s:4:"crop";b:0;s:4:"file";s:25:"humberger-svgrepo-com.svg";s:9:"mime-type";s:13:"image/svg+xml";}s:12:"medium_large";a:5:{s:5:"width";s:3:"768";s:6:"height";d:768;s:4:"crop";b:0;s:4:"file";s:25:"humberger-svgrepo-com.svg";s:9:"mime-type";s:13:"image/svg+xml";}s:5:"large";a:5:{s:5:"width";s:4:"1024";s:6:"height";d:1024;s:4:"crop";b:0;s:4:"file";s:25:"humberger-svgrepo-com.svg";s:9:"mime-type";s:13:"image/svg+xml";}s:9:"1536x1536";a:5:{s:5:"width";b:0;s:6:"height";d:0;s:4:"crop";b:0;s:4:"file";s:25:"humberger-svgrepo-com.svg";s:9:"mime-type";s:13:"image/svg+xml";}s:9:"2048x2048";a:5:{s:5:"width";b:0;s:6:"height";d:0;s:4:"crop";b:0;s:4:"file";s:25:"humberger-svgrepo-com.svg";s:9:"mime-type";s:13:"image/svg+xml";}s:14:"post-thumbnail";a:5:{s:5:"width";b:0;s:6:"height";d:0;s:4:"crop";b:0;s:4:"file";s:25:"humberger-svgrepo-com.svg";s:9:"mime-type";s:13:"image/svg+xml";}}}
```

This can cause issues in some scenarios. E.g. the WPML Media Translation plugin uses `wp_get_attachment_metadata` to generate the image URL, and this will get the information stored in `_wp_attachment_metadata`. As the path is missing there, the SVG images are not found.

## Debug
After checking the code from `bodhi_svgs_generate_svg_attachment_metadata()`, I found that we have a `$relative_path` variable there, but this variable is not being used anywhere.

It seems that it should be used within the following snippet. If I do this, the problem is solved:
```php
// Line 128
$metadata = array(
  'width'		=> intval($dimensions->width),
  'height'	=> intval($dimensions->height),
  'file'		=> $relative_path // replaced $filename here
);
```


