### PR TITLE
Phase 0: compatibility-covenant test harness (green baseline for v3.0)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -32,3 +32,13 @@
 /bin
 /composer.json
 /composer.lock
+
+# Test harness (never shipped)
+/tests
+/node_modules
+/package.json
+/package-lock.json
+/.wp-env.json
+/.wp-env.override.json
+/playwright-report
+/test-results

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run Plugin Check
         run: |
           wp-env run cli wp plugin check svg-support \
-            --exclude-directories=.git,.github,.wordpress-org,node_modules,bin \
-            --exclude-files=.DS_Store,.gitignore,.gitattributes,.distignore,README.md,LICENSE,composer.json,composer.lock,.wp-env.json \
+            --exclude-directories=.git,.github,.wordpress-org,node_modules,bin,tests \
+            --exclude-files=.DS_Store,.gitignore,.gitattributes,.distignore,README.md,LICENSE,composer.json,composer.lock,.wp-env.json,package.json,package-lock.json \
             --ignore-codes=stable_tag_mismatch \
             --require=./wp-content/plugins/plugin-check/cli.php

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,83 @@
+name: Tests
+
+# Regression suite for the compatibility covenant. Two jobs:
+#   1. sanitizer  — fast, no Docker: runs the standalone sanitizer corpus
+#                   against the real vendored library + the plugin's whitelists.
+#   2. phpunit    — WordPress integration tests via wp-env (settings sanitize
+#                   contract, file-based sanitizer, upload-prefilter validation
+#                   incl. the .svgz XSS regression).
+#
+# wp-env is booted the same way as plugin-check.yml (no URL plugins, Node 20,
+# verified start with retry) to dodge the known wp-env silent-exit bug.
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  sanitizer:
+    name: Sanitizer corpus (standalone)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: dom, libxml, mbstring, zlib
+          coverage: none
+
+      - name: Run standalone sanitizer suite
+        run: php tests/sanitizer/run.php
+
+  phpunit:
+    name: PHPUnit (wp-env, PHP ${{ matrix.php }} / WP latest)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 7.4 = version floor, 8.2 = mainstream. PHPUnit 9.6 is rock-solid on
+        # both. 8.4 is deferred until a PHPUnit 10/11 bump (9.6 turns 8.4
+        # deprecations into failures). Add specific older-WP legs the same way.
+        php: [ '7.4', '8.2' ]
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Configure wp-env (pin PHP for this matrix leg, latest stable WP)
+        run: |
+          # No URL plugins — that triggers the wp-env start bug (see plugin-check.yml).
+          cat > .wp-env.json <<JSON
+          {
+            "core": null,
+            "phpVersion": "${{ matrix.php }}",
+            "plugins": [ "." ]
+          }
+          JSON
+          npm -g --no-fund install @wordpress/env
+
+      - name: Start wp-env
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: |
+            wp-env start --update
+            wp-env run tests-cli wp cli info
+
+      - name: Install PHPUnit dependencies
+        run: wp-env run tests-cli --env-cwd=wp-content/plugins/svg-support/tests/phpunit composer install --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: wp-env run tests-cli --env-cwd=wp-content/plugins/svg-support/tests/phpunit ./vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,3 +81,42 @@ jobs:
 
       - name: Run PHPUnit
         run: wp-env run tests-cli --env-cwd=wp-content/plugins/svg-support/tests/phpunit ./vendor/bin/phpunit
+
+  e2e:
+    name: Playwright e2e (wp-env)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install node dependencies
+        run: npm install --no-fund --no-audit
+
+      - name: Start wp-env (committed .wp-env.json, dev site on :8888)
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          shell: bash
+          command: |
+            npx wp-env start --update
+            npx wp-env run cli wp cli info
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e specs
+        run: npm run test:e2e
+        env:
+          WP_BASE_URL: http://localhost:8888
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: tests/e2e/artifacts
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@
 
 # Other ignores
 composer.lock
+
+# Test harness
+/node_modules/
+/tests/phpunit/vendor/
+/tests/phpunit/composer.lock
+/tests/e2e/artifacts/
+/playwright-report/
+/test-results/
+/.wp-env.override.json

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,11 @@
+{
+	"core": null,
+	"plugins": [ "." ],
+	"port": 8888,
+	"testsPort": 8889,
+	"config": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": false
+	}
+}

--- a/bin/plugin-check.sh
+++ b/bin/plugin-check.sh
@@ -68,8 +68,8 @@ if [[ ! -S "$SOCK" ]]; then
 fi
 
 # Mirror .distignore so we only report on files that actually ship.
-EXCLUDE_DIRS=".git,.github,.wordpress-org,node_modules,bin"
-EXCLUDE_FILES=".DS_Store,.gitignore,.gitattributes,.distignore,README.md,LICENSE,composer.json,composer.lock"
+EXCLUDE_DIRS=".git,.github,.wordpress-org,node_modules,bin,tests"
+EXCLUDE_FILES=".DS_Store,.gitignore,.gitattributes,.distignore,README.md,LICENSE,composer.json,composer.lock,package.json,package-lock.json,.wp-env.json"
 
 echo "▶ Plugin Check: $PLUGIN_SLUG  (site: $LOCAL_SITE, php ${SITE_PHP:-?})"
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "svg-support-dev",
+	"private": true,
+	"description": "Development harness for the SVG Support plugin (wp-env, Playwright e2e, PHPUnit). Not shipped to WordPress.org.",
+	"devDependencies": {
+		"@playwright/test": "^1.49.0",
+		"@wordpress/e2e-test-utils-playwright": "^1.16.0",
+		"@wordpress/env": "^10.17.0"
+	},
+	"scripts": {
+		"env:start": "wp-env start",
+		"env:stop": "wp-env stop",
+		"env:destroy": "wp-env destroy",
+		"test:php": "wp-env run tests-cli --env-cwd=wp-content/plugins/svg-support tests/phpunit/vendor/bin/phpunit -c tests/phpunit/phpunit.xml",
+		"test:e2e": "playwright test --config tests/e2e/playwright.config.js",
+		"test": "npm run test:php && npm run test:e2e"
+	}
+}

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,0 +1,29 @@
+// @ts-check
+const { chromium } = require( '@playwright/test' );
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+/**
+ * Log in to wp-admin once as the default wp-env admin (admin / password) and
+ * persist the auth cookies so every spec starts authenticated.
+ */
+module.exports = async () => {
+	const baseURL = process.env.WP_BASE_URL || 'http://localhost:8888';
+	const user = process.env.WP_ADMIN_USER || 'admin';
+	const pass = process.env.WP_ADMIN_PASS || 'password';
+
+	const artifacts = path.join( __dirname, 'artifacts' );
+	fs.mkdirSync( artifacts, { recursive: true } );
+
+	const browser = await chromium.launch();
+	const page = await browser.newPage();
+
+	await page.goto( `${ baseURL }/wp-login.php` );
+	await page.fill( '#user_login', user );
+	await page.fill( '#user_pass', pass );
+	await page.click( '#wp-submit' );
+	await page.waitForSelector( '#wpadminbar', { timeout: 30000 } );
+
+	await page.context().storageState( { path: path.join( artifacts, 'admin-state.json' ) } );
+	await browser.close();
+};

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -1,0 +1,34 @@
+// @ts-check
+const { defineConfig, devices } = require( '@playwright/test' );
+const path = require( 'path' );
+
+/**
+ * Playwright config for the SVG Support e2e suite. Targets the wp-env dev site
+ * (npm run env:start) on http://localhost:8888. In CI the same wp-env boot is
+ * reused. Auth state is created once by tests/e2e/global-setup.js.
+ *
+ * Paths are absolute (via __dirname) so they resolve identically regardless of
+ * the working directory the runner invokes Playwright from.
+ */
+const BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8888';
+const ARTIFACTS = path.join( __dirname, 'artifacts' );
+
+module.exports = defineConfig( {
+	testDir: path.join( __dirname, 'specs' ),
+	outputDir: ARTIFACTS,
+	fullyParallel: false,
+	forbidOnly: !! process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	workers: 1,
+	reporter: process.env.CI ? [ [ 'github' ], [ 'list' ] ] : [ [ 'list' ] ],
+	globalSetup: require.resolve( './global-setup' ),
+	use: {
+		baseURL: BASE_URL,
+		storageState: path.join( ARTIFACTS, 'admin-state.json' ),
+		trace: 'retain-on-failure',
+		screenshot: 'only-on-failure',
+	},
+	projects: [
+		{ name: 'chromium', use: { ...devices[ 'Desktop Chrome' ] } },
+	],
+} );

--- a/tests/e2e/specs/settings-autosave.spec.js
+++ b/tests/e2e/specs/settings-autosave.spec.js
@@ -47,8 +47,16 @@ test.describe( 'SVG Support settings — autosave & reveal', () => {
 	test( 'css_target text input autosaves and persists', async ( { page } ) => {
 		await page.goto( SETTINGS );
 
+		// css_target lives inside the Advanced Mode section, which is hidden
+		// while Advanced Mode is off. Enable it first so the field is reachable.
+		const toggle = page.locator( ADVANCED );
+		if ( ! ( await toggle.isChecked() ) ) {
+			await toggle.check( { force: true } );
+			await expect( page.locator( '#svgs-savestate' ) ).toHaveAttribute( 'data-state', 'saved', { timeout: 6000 } );
+		}
+
 		const input = page.locator( CSS_TARGET );
-		await expect( input ).toHaveCount( 1 );
+		await expect( input ).toBeVisible();
 
 		const value = 'style-svg-e2e';
 		await input.fill( value );
@@ -61,6 +69,10 @@ test.describe( 'SVG Support settings — autosave & reveal', () => {
 		// Restore empty (falls back to the default "style-svg" at render time).
 		await page.locator( CSS_TARGET ).fill( '' );
 		await expect( page.locator( '#svgs-savestate' ) ).toHaveAttribute( 'data-state', 'saved', { timeout: 8000 } );
+
+		// Leave Advanced Mode off so the site is as we found it.
+		await page.locator( ADVANCED ).uncheck( { force: true } );
+		await expect( page.locator( '#svgs-savestate' ) ).toHaveAttribute( 'data-state', 'saved', { timeout: 6000 } );
 	} );
 
 	test( 'classic no-JS fallback form is intact', async ( { page } ) => {

--- a/tests/e2e/specs/settings-autosave.spec.js
+++ b/tests/e2e/specs/settings-autosave.spec.js
@@ -1,0 +1,76 @@
+// @ts-check
+const { test, expect } = require( '@playwright/test' );
+
+const SETTINGS = '/wp-admin/options-general.php?page=svg-support';
+const ADVANCED = 'input[name="bodhi_svgs_settings[advanced_mode]"]';
+const CSS_TARGET = 'input[name="bodhi_svgs_settings[css_target]"]';
+
+/**
+ * Exercises the redesigned settings screen shipped in 2.6.0: debounced AJAX
+ * autosave, the live Advanced Mode reveal, and the classic (no-JS) fallback
+ * form. These are the new surfaces the covenant most needs to keep working.
+ */
+test.describe( 'SVG Support settings — autosave & reveal', () => {
+
+	test( 'Advanced Mode reveals sections live, autosaves, and persists', async ( { page } ) => {
+		await page.goto( SETTINGS );
+
+		const toggle = page.locator( ADVANCED );
+		await expect( toggle ).toHaveCount( 1 );
+
+		// Normalize to OFF first so the test is deterministic.
+		if ( await toggle.isChecked() ) {
+			await toggle.uncheck( { force: true } );
+			await expect( page.locator( '#svgs-savestate' ) ).toHaveAttribute( 'data-state', 'saved', { timeout: 6000 } );
+		}
+
+		const firstAdvanced = page.locator( '.svgs-advanced' ).first();
+		await expect( firstAdvanced ).toBeHidden();
+
+		// Turn Advanced Mode ON — sections should reveal immediately (no reload).
+		await toggle.check( { force: true } );
+		await expect( firstAdvanced ).toBeVisible();
+
+		// The save-state chip should reach "saved".
+		await expect( page.locator( '#svgs-savestate' ) ).toHaveAttribute( 'data-state', 'saved', { timeout: 6000 } );
+
+		// Persistence: reload and confirm it stuck.
+		await page.reload();
+		await expect( page.locator( ADVANCED ) ).toBeChecked();
+		await expect( page.locator( '.svgs-advanced' ).first() ).toBeVisible();
+
+		// Restore OFF so we leave the site as we found it.
+		await page.locator( ADVANCED ).uncheck( { force: true } );
+		await expect( page.locator( '#svgs-savestate' ) ).toHaveAttribute( 'data-state', 'saved', { timeout: 6000 } );
+	} );
+
+	test( 'css_target text input autosaves and persists', async ( { page } ) => {
+		await page.goto( SETTINGS );
+
+		const input = page.locator( CSS_TARGET );
+		await expect( input ).toHaveCount( 1 );
+
+		const value = 'style-svg-e2e';
+		await input.fill( value );
+		// Typing debounce is 800ms; the chip confirms the save landed.
+		await expect( page.locator( '#svgs-savestate' ) ).toHaveAttribute( 'data-state', 'saved', { timeout: 8000 } );
+
+		await page.reload();
+		await expect( page.locator( CSS_TARGET ) ).toHaveValue( value );
+
+		// Restore empty (falls back to the default "style-svg" at render time).
+		await page.locator( CSS_TARGET ).fill( '' );
+		await expect( page.locator( '#svgs-savestate' ) ).toHaveAttribute( 'data-state', 'saved', { timeout: 8000 } );
+	} );
+
+	test( 'classic no-JS fallback form is intact', async ( { page } ) => {
+		await page.goto( SETTINGS );
+
+		// The form posts to options.php with the correct settings group nonce,
+		// so saving still works if AJAX is blocked / JS disabled.
+		const form = page.locator( 'form#svgs-settings-form' );
+		await expect( form ).toHaveAttribute( 'action', /options\.php$/ );
+		await expect( form.locator( 'input[name="option_page"][value="bodhi_svgs_settings_group"]' ) ).toHaveCount( 1 );
+		await expect( form.locator( 'input[type="submit"]' ) ).toHaveCount( 1 );
+	} );
+} );

--- a/tests/fixtures/benign/animate-smil.svg
+++ b/tests/fixtures/benign/animate-smil.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100"><circle cx="50" cy="50" r="20" fill="#ec4899"><animate attributeName="r" values="20;40;20" dur="2s" repeatCount="indefinite"/></circle></svg>

--- a/tests/fixtures/benign/currentcolor.svg
+++ b/tests/fixtures/benign/currentcolor.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M12 21s-7-4.35-7-10a4 4 0 0 1 7-2 4 4 0 0 1 7 2c0 5.65-7 10-7 10z" fill="currentColor"/></svg>

--- a/tests/fixtures/benign/embedded-style.svg
+++ b/tests/fixtures/benign/embedded-style.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100"><style>.a{fill:#9333ea}.b{fill:#f59e0b}</style><rect class="a" width="50" height="100"/><rect class="b" x="50" width="50" height="100"/></svg>

--- a/tests/fixtures/benign/gradient.svg
+++ b/tests/fixtures/benign/gradient.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#06b6d4"/><stop offset="100%" stop-color="#3b82f6"/></linearGradient></defs><rect width="100" height="100" fill="url(#g)"/></svg>

--- a/tests/fixtures/benign/nested-svg.svg
+++ b/tests/fixtures/benign/nested-svg.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100" width="200" height="100"><rect width="200" height="100" fill="#f1f5f9"/><svg x="10" y="10" width="80" height="80" viewBox="0 0 24 24"><path d="M4 12h16" stroke="#0f172a" stroke-width="2"/></svg></svg>

--- a/tests/fixtures/benign/simple-icon.svg
+++ b/tests/fixtures/benign/simple-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path d="M12 2 2 22h20L12 2z" fill="#e11d48"/></svg>

--- a/tests/fixtures/benign/text-element.svg
+++ b/tests/fixtures/benign/text-element.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40" width="120" height="40"><text x="10" y="26" font-family="sans-serif" font-size="18" fill="#111827">SVG OK</text></svg>

--- a/tests/fixtures/benign/title-desc-a11y.svg
+++ b/tests/fixtures/benign/title-desc-a11y.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-labelledby="t d"><title id="t">Home</title><desc id="d">A house icon</desc><path d="M3 12 12 3l9 9v9H3z" fill="none" stroke="#0f172a" stroke-width="2"/></svg>

--- a/tests/fixtures/benign/use-symbol.svg
+++ b/tests/fixtures/benign/use-symbol.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 24" width="48" height="24"><defs><symbol id="dot" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" fill="#16a34a"/></symbol></defs><use href="#dot" x="0"/><use xlink:href="#dot" x="24"/></svg>

--- a/tests/fixtures/benign/viewbox-no-dimensions.svg
+++ b/tests/fixtures/benign/viewbox-no-dimensions.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="#2563eb"/></svg>

--- a/tests/fixtures/malicious/anchor-javascript-href.svg
+++ b/tests/fixtures/malicious/anchor-javascript-href.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><a href="javascript:alert('xss-anchor-href')"><rect width="24" height="24" fill="#000"/></a></svg>

--- a/tests/fixtures/malicious/animate-values-javascript.svg
+++ b/tests/fixtures/malicious/animate-values-javascript.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" width="24" height="24"><a><animate attributeName="xlink:href" values="javascript:alert('xss-animate')" begin="0s"/><rect width="24" height="24" fill="#000"/></a></svg>

--- a/tests/fixtures/malicious/billion-laughs.svg
+++ b/tests/fixtures/malicious/billion-laughs.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg [
+  <!ENTITY lol "lol">
+  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+]>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><text>&lol4;</text></svg>

--- a/tests/fixtures/malicious/external-image-href.svg
+++ b/tests/fixtures/malicious/external-image-href.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" width="24" height="24"><image xlink:href="http://evil.example.com/track.svg" width="24" height="24"/></svg>

--- a/tests/fixtures/malicious/external-use-href.svg
+++ b/tests/fixtures/malicious/external-use-href.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" width="24" height="24"><use xlink:href="http://evil.example.com/payload.svg#x"/></svg>

--- a/tests/fixtures/malicious/foreignobject-script.svg
+++ b/tests/fixtures/malicious/foreignobject-script.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><foreignObject width="24" height="24"><body xmlns="http://www.w3.org/1999/xhtml"><script>alert('xss-foreignobject')</script></body></foreignObject></svg>

--- a/tests/fixtures/malicious/handler-element.svg
+++ b/tests/fixtures/malicious/handler-element.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:ev="http://www.w3.org/2001/xml-events" viewBox="0 0 24 24" width="24" height="24"><handler ev:event="load">alert('xss-handler')</handler><rect width="24" height="24" fill="#000"/></svg>

--- a/tests/fixtures/malicious/mixedcase-xlink-href.svg
+++ b/tests/fixtures/malicious/mixedcase-xlink-href.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" width="24" height="24"><a xlink:hReF="javascript:alert('xss-mixedcase')"><rect width="24" height="24" fill="#000"/></a></svg>

--- a/tests/fixtures/malicious/onclick-attr.svg
+++ b/tests/fixtures/malicious/onclick-attr.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><rect width="24" height="24" fill="#000" onclick="alert('xss-onclick')"/></svg>

--- a/tests/fixtures/malicious/onload-attr.svg
+++ b/tests/fixtures/malicious/onload-attr.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" onload="alert('xss-onload')"><path d="M4 4h16v16H4z" fill="#000"/></svg>

--- a/tests/fixtures/malicious/script-tag.svg
+++ b/tests/fixtures/malicious/script-tag.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><script>alert('xss-script-tag')</script><path d="M4 4h16v16H4z" fill="#000"/></svg>

--- a/tests/fixtures/malicious/set-onbegin.svg
+++ b/tests/fixtures/malicious/set-onbegin.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><rect width="24" height="24" fill="#000"><set attributeName="fill" to="red" onbegin="alert('xss-set-onbegin')"/></rect></svg>

--- a/tests/fixtures/malicious/xlink-javascript-href.svg
+++ b/tests/fixtures/malicious/xlink-javascript-href.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" width="24" height="24"><a xlink:href="javascript:alert('xss-xlink-href')"><rect width="24" height="24" fill="#000"/></a></svg>

--- a/tests/fixtures/malicious/xxe-entity.svg
+++ b/tests/fixtures/malicious/xxe-entity.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><text x="0" y="12">&xxe;</text></svg>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -25,6 +25,11 @@ require_once $_tests_dir . '/includes/functions.php';
 tests_add_filter(
 	'muplugins_loaded',
 	function () {
+		// svg-support.php assigns $sanitizer at file top level. Loaded normally
+		// by WordPress that is global scope; required inside this closure it
+		// would be closure-local, so declare the globals first to bind the
+		// assignments to the true globals the plugin's functions read.
+		global $sanitizer, $bodhi_svgs_options;
 		require dirname( __DIR__, 2 ) . '/svg-support.php';
 	}
 );

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * PHPUnit bootstrap: loads the WordPress test suite provided by wp-env
+ * (WP_TESTS_DIR is set inside the wp-env containers) and the plugin.
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/wordpress-phpunit';
+}
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', __DIR__ . '/vendor/yoast/phpunit-polyfills' );
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo "Could not find the WordPress test suite at {$_tests_dir}. Run inside wp-env (npm run test:php) or set WP_TESTS_DIR." . PHP_EOL;
+	exit( 1 );
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+tests_add_filter(
+	'muplugins_loaded',
+	function () {
+		require dirname( __DIR__, 2 ) . '/svg-support.php';
+	}
+);
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/phpunit/composer.json
+++ b/tests/phpunit/composer.json
@@ -1,0 +1,13 @@
+{
+	"description": "PHP test dependencies, isolated from the plugin's shipped vendor/ directory.",
+	"require-dev": {
+		"phpunit/phpunit": "^9.6",
+		"yoast/phpunit-polyfills": "^2.0"
+	},
+	"config": {
+		"platform": {
+			"php": "7.4.33"
+		},
+		"optimize-autoloader": true
+	}
+}

--- a/tests/phpunit/phpunit.xml
+++ b/tests/phpunit/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite name="svg-support">
+			<directory prefix="test-" suffix=".php">./tests</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/phpunit/tests/test-sanitize-corpus.php
+++ b/tests/phpunit/tests/test-sanitize-corpus.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Exercises the real file-based sanitizer bodhi_svgs_sanitize() (WP_Filesystem
+ * read/write, global $sanitizer, gzip round-trip) against the fixture corpus.
+ * Complements the standalone runner in tests/sanitizer/run.php, which tests the
+ * same engine without WordPress — this one proves the WP integration path.
+ *
+ * @group sanitize
+ * @group covenant
+ */
+class Test_Sanitize_Corpus extends WP_UnitTestCase {
+
+	/** @var string */
+	private $work;
+
+	public function set_up() {
+		parent::set_up();
+		$this->work = wp_tempnam( 'svgs-corpus' );
+	}
+
+	public function tear_down() {
+		if ( $this->work && file_exists( $this->work ) ) {
+			@unlink( $this->work );
+		}
+		parent::tear_down();
+	}
+
+	private function fixtures( $dir ) {
+		return glob( dirname( __DIR__, 2 ) . "/fixtures/$dir/*.svg" );
+	}
+
+	/** Copy a fixture to a writable temp file and sanitize it in place. */
+	private function sanitize_fixture( $path ) {
+		copy( $path, $this->work );
+		$ok = bodhi_svgs_sanitize( $this->work );
+		return array( $ok, file_get_contents( $this->work ) );
+	}
+
+	public function test_function_exists() {
+		$this->assertTrue( function_exists( 'bodhi_svgs_sanitize' ) );
+	}
+
+	public function test_benign_fixtures_survive() {
+		foreach ( $this->fixtures( 'benign' ) as $path ) {
+			$name = basename( $path );
+			list( $ok, $clean ) = $this->sanitize_fixture( $path );
+			$this->assertTrue( $ok, "$name should sanitize without error" );
+			$this->assertStringContainsStringIgnoringCase( '<svg', $clean, "$name should remain an SVG" );
+		}
+	}
+
+	public function test_malicious_fixtures_are_neutralized() {
+		$forbidden_global = array( '<script', 'javascript:', 'onload=', 'onclick=', 'onbegin=', 'onmouseover=' );
+		foreach ( $this->fixtures( 'malicious' ) as $path ) {
+			$name = basename( $path );
+			list( $ok, $clean ) = $this->sanitize_fixture( $path );
+			// Sanitizer may neutralize (return true + cleaned) or reject (false).
+			if ( $ok === false ) {
+				continue;
+			}
+			$hay = strtolower( $clean );
+			foreach ( $forbidden_global as $bad ) {
+				$this->assertStringNotContainsString( strtolower( $bad ), $hay, "$name must not retain $bad" );
+			}
+			// evil.example.com must be gone for the remote <use> case; the remote
+			// <image> case is a documented current limitation covered explicitly
+			// (and separately) so we don't assert its absence here.
+			$this->assertLessThan( 65536, strlen( $clean ), "$name output should stay bounded" );
+		}
+	}
+
+	/**
+	 * Gzipped .svgz round-trip: a gzip-compressed SVG carrying a <script> must
+	 * come back sanitized AND still gzip-framed (so it round-trips on disk).
+	 */
+	public function test_svgz_gzip_roundtrip() {
+		$dirty = file_get_contents( dirname( __DIR__, 2 ) . '/fixtures/malicious/script-tag.svg' );
+		file_put_contents( $this->work, gzencode( $dirty ) );
+
+		$ok = bodhi_svgs_sanitize( $this->work );
+		$this->assertTrue( $ok, 'gzipped .svgz should sanitize without error' );
+
+		$out = file_get_contents( $this->work );
+		$this->assertSame( "\x1f\x8b\x08", substr( $out, 0, 3 ), 'output should remain gzip-framed' );
+
+		$decoded = gzdecode( $out );
+		$this->assertStringNotContainsStringIgnoringCase( '<script', $decoded, 'decoded payload must be clean' );
+		$this->assertStringContainsString( '<rect', $decoded, 'decoded payload should keep the safe shape' );
+	}
+
+	/**
+	 * Documented current behavior — remote <image href> passes through. Locked
+	 * so a dependency bump that changes it is caught here.
+	 */
+	public function test_remote_image_href_current_behavior() {
+		list( $ok, $clean ) = $this->sanitize_fixture( dirname( __DIR__, 2 ) . '/fixtures/malicious/external-image-href.svg' );
+		$this->assertTrue( $ok );
+		$this->assertStringContainsString( 'evil.example.com', $clean, 'remote <image href> currently survives (known limitation)' );
+	}
+
+	public function test_remote_use_href_is_stripped() {
+		list( $ok, $clean ) = $this->sanitize_fixture( dirname( __DIR__, 2 ) . '/fixtures/malicious/external-use-href.svg' );
+		$this->assertTrue( $ok );
+		$this->assertStringNotContainsString( 'evil.example.com', $clean, 'remote <use href> should be stripped' );
+	}
+}

--- a/tests/phpunit/tests/test-sanitize-corpus.php
+++ b/tests/phpunit/tests/test-sanitize-corpus.php
@@ -85,7 +85,8 @@ class Test_Sanitize_Corpus extends WP_UnitTestCase {
 
 		$decoded = gzdecode( $out );
 		$this->assertStringNotContainsStringIgnoringCase( '<script', $decoded, 'decoded payload must be clean' );
-		$this->assertStringContainsString( '<rect', $decoded, 'decoded payload should keep the safe shape' );
+		// script-tag.svg carries a <path> as its safe shape.
+		$this->assertStringContainsString( '<path', $decoded, 'decoded payload should keep the safe shape' );
 	}
 
 	/**

--- a/tests/phpunit/tests/test-settings-sanitize.php
+++ b/tests/phpunit/tests/test-settings-sanitize.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * The compatibility covenant, encoded: bodhi_svgs_settings_sanitize() must
+ * behave identically to how it did in 2.6.0, because it is the single gate both
+ * the classic options.php save and the AJAX autosave run through. Any change to
+ * option shapes, defaults, or legacy-value handling would silently alter what a
+ * million existing sites store. These tests lock that behavior.
+ *
+ * @group settings
+ * @group covenant
+ */
+class Test_Settings_Sanitize extends WP_UnitTestCase {
+
+	public function test_function_exists() {
+		$this->assertTrue( function_exists( 'bodhi_svgs_settings_sanitize' ) );
+	}
+
+	/* ---- css_target ---- */
+
+	public function test_css_target_is_sanitized_and_attr_escaped() {
+		$out = bodhi_svgs_settings_sanitize( array( 'css_target' => 'style-svg' ) );
+		$this->assertSame( 'style-svg', $out['css_target'] );
+	}
+
+	public function test_css_target_strips_markup() {
+		$out = bodhi_svgs_settings_sanitize( array( 'css_target' => '"><script>alert(1)</script>' ) );
+		// sanitize_text_field strips the tags; esc_attr encodes the quote.
+		$this->assertStringNotContainsString( '<script', $out['css_target'] );
+		$this->assertStringNotContainsString( '"', $out['css_target'] );
+	}
+
+	/* ---- sanitize_svg_front_end (the one key stored as false, not absent) ---- */
+
+	public function test_front_end_sanitize_on_preserved() {
+		$out = bodhi_svgs_settings_sanitize( array( 'sanitize_svg_front_end' => 'on' ) );
+		$this->assertSame( 'on', $out['sanitize_svg_front_end'] );
+	}
+
+	public function test_front_end_sanitize_absent_becomes_false() {
+		$out = bodhi_svgs_settings_sanitize( array() );
+		$this->assertFalse( $out['sanitize_svg_front_end'] );
+	}
+
+	public function test_front_end_sanitize_unexpected_value_becomes_false() {
+		$out = bodhi_svgs_settings_sanitize( array( 'sanitize_svg_front_end' => '1' ) );
+		$this->assertFalse( $out['sanitize_svg_front_end'] );
+	}
+
+	/* ---- restrict: absent -> ['none'], strings coerced to array ---- */
+
+	public function test_restrict_absent_becomes_none_sentinel() {
+		$out = bodhi_svgs_settings_sanitize( array() );
+		$this->assertSame( array( 'none' ), $out['restrict'] );
+	}
+
+	public function test_restrict_array_preserved() {
+		$out = bodhi_svgs_settings_sanitize( array( 'restrict' => array( 'administrator', 'editor' ) ) );
+		$this->assertSame( array( 'administrator', 'editor' ), $out['restrict'] );
+	}
+
+	public function test_restrict_legacy_string_coerced_to_array() {
+		// Historical installs stored 'on' / 'none' as scalars. (array) must not fatal.
+		$out = bodhi_svgs_settings_sanitize( array( 'restrict' => 'administrator' ) );
+		$this->assertSame( array( 'administrator' ), $out['restrict'] );
+	}
+
+	/* ---- sanitize_on_upload_roles: absent -> ['none'] ---- */
+
+	public function test_bypass_roles_absent_becomes_none_sentinel() {
+		$out = bodhi_svgs_settings_sanitize( array() );
+		$this->assertSame( array( 'none' ), $out['sanitize_on_upload_roles'] );
+	}
+
+	public function test_bypass_roles_array_preserved() {
+		$out = bodhi_svgs_settings_sanitize( array( 'sanitize_on_upload_roles' => array( 'administrator' ) ) );
+		$this->assertSame( array( 'administrator' ), $out['sanitize_on_upload_roles'] );
+	}
+
+	/* ---- checkbox 'on' keys pass through untouched ---- */
+
+	public function test_checkbox_on_values_pass_through() {
+		$in = array(
+			'advanced_mode'   => 'on',
+			'minify_svg'      => 'on',
+			'frontend_css'    => 'on',
+			'js_foot_choice'  => 'on',
+			'use_vanilla_js'  => 'on',
+			'use_expanded_js' => 'on',
+			'force_inline_svg' => 'on',
+			'auto_insert_class' => 'on',
+			'del_plugin_data' => 'on',
+			'skip_nested_svg' => '1',
+		);
+		$out = bodhi_svgs_settings_sanitize( $in );
+		foreach ( $in as $k => $v ) {
+			$this->assertSame( $v, $out[$k], "checkbox key $k must pass through unchanged" );
+		}
+	}
+
+	/**
+	 * Full round-trip on a realistic settings array: every one of the 14
+	 * documented keys present, asserting the exact stored shape. This is the
+	 * canary — if the option contract drifts, this fails.
+	 */
+	public function test_full_realistic_payload_shape() {
+		$in = array(
+			'restrict'               => array( 'administrator' ),
+			'sanitize_on_upload_roles' => array(),
+			'sanitize_svg_front_end' => 'on',
+			'advanced_mode'          => 'on',
+			'css_target'             => 'style-svg',
+			'minify_svg'             => 'on',
+			'frontend_css'           => 'on',
+			'skip_nested_svg'        => '1',
+			'js_foot_choice'         => 'on',
+			'use_vanilla_js'         => 'on',
+			'use_expanded_js'        => 'on',
+			'force_inline_svg'       => 'on',
+			'auto_insert_class'      => 'on',
+			'del_plugin_data'        => 'on',
+		);
+		$out = bodhi_svgs_settings_sanitize( $in );
+
+		$this->assertSame( array( 'administrator' ), $out['restrict'] );
+		$this->assertSame( array(), $out['sanitize_on_upload_roles'] );
+		$this->assertSame( 'on', $out['sanitize_svg_front_end'] );
+		$this->assertSame( 'style-svg', $out['css_target'] );
+		$this->assertSame( '1', $out['skip_nested_svg'] );
+		// No key is dropped.
+		foreach ( array_keys( $in ) as $k ) {
+			$this->assertArrayHasKey( $k, $out );
+		}
+	}
+}

--- a/tests/phpunit/tests/test-upload-validation.php
+++ b/tests/phpunit/tests/test-upload-validation.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Covers the upload prefilter bodhi_svgs_sanitize_svg() — the gatekeeper for
+ * media-library and sideload uploads. Exercised through the SIDELOAD filter
+ * (wp_handle_sideload_prefilter), which the function treats as always-sanitize
+ * and nonce-exempt, so these tests hit the validation + sanitization branch
+ * without needing a media-form nonce.
+ *
+ * The headline case is the .svgz XSS regression (2.5.17 / CVE fixes): a
+ * plaintext file with a .svgz extension carrying a <script> must NOT bypass
+ * sanitization.
+ *
+ * @group upload
+ * @group covenant
+ * @group security
+ */
+class Test_Upload_Validation extends WP_UnitTestCase {
+
+	private $tmp = array();
+
+	public function set_up() {
+		parent::set_up();
+		// Default sanitize behavior: nobody bypasses.
+		$opts = get_option( 'bodhi_svgs_settings', array() );
+		$opts['sanitize_on_upload_roles'] = array( 'none' );
+		update_option( 'bodhi_svgs_settings', $opts );
+		$GLOBALS['bodhi_svgs_options'] = $opts;
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	public function tear_down() {
+		foreach ( $this->tmp as $f ) {
+			if ( file_exists( $f ) ) {
+				@unlink( $f );
+			}
+		}
+		$this->tmp = array();
+		parent::tear_down();
+	}
+
+	private function make_upload( $basename, $bytes ) {
+		$path = wp_tempnam( $basename );
+		file_put_contents( $path, $bytes );
+		$this->tmp[] = $path;
+		return array(
+			'name'     => $basename,
+			'type'     => 'image/svg+xml',
+			'tmp_name' => $path,
+			'error'    => 0,
+			'size'     => strlen( $bytes ),
+		);
+	}
+
+	/** Route a fake upload through the sideload prefilter (nonce-exempt path). */
+	private function run_prefilter( $file ) {
+		return apply_filters( 'wp_handle_sideload_prefilter', $file );
+	}
+
+	public function test_valid_svg_passes_and_is_sanitized() {
+		$svg  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><script>alert(1)</script><rect width="24" height="24"/></svg>';
+		$file = $this->make_upload( 'good.svg', $svg );
+
+		$res = $this->run_prefilter( $file );
+
+		$this->assertSame( '', (string) ( $res['error'] ?? '' ), 'valid SVG should not set an error' );
+		$cleaned = file_get_contents( $res['tmp_name'] );
+		$this->assertStringNotContainsStringIgnoringCase( '<script', $cleaned, 'script must be stripped on upload' );
+		$this->assertStringContainsString( '<rect', $cleaned, 'safe content should survive' );
+	}
+
+	/**
+	 * The .svgz XSS regression: a plaintext (NOT gzipped) file named .svgz that
+	 * contains a script must be sanitized, not passed through untouched.
+	 */
+	public function test_plaintext_svgz_is_sanitized_not_bypassed() {
+		$svg  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><script>alert("svgz-poc")</script><rect width="24" height="24"/></svg>';
+		$file = $this->make_upload( 'sneaky.svgz', $svg ); // plaintext, .svgz extension
+
+		$res = $this->run_prefilter( $file );
+
+		$this->assertSame( '', (string) ( $res['error'] ?? '' ), 'plaintext .svgz that is valid SVG should be accepted (then sanitized)' );
+		$cleaned = file_get_contents( $res['tmp_name'] );
+		$this->assertStringNotContainsStringIgnoringCase( '<script', $cleaned, '.svgz must not bypass sanitization' );
+	}
+
+	/** A genuinely gzipped .svgz with a script must also be sanitized. */
+	public function test_gzipped_svgz_is_sanitized() {
+		$svg  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><script>alert(1)</script><rect width="24" height="24"/></svg>';
+		$file = $this->make_upload( 'real.svgz', gzencode( $svg ) );
+
+		$res = $this->run_prefilter( $file );
+
+		$this->assertSame( '', (string) ( $res['error'] ?? '' ) );
+		$out = file_get_contents( $res['tmp_name'] );
+		$decoded = ( substr( $out, 0, 3 ) === "\x1f\x8b\x08" ) ? gzdecode( $out ) : $out;
+		$this->assertStringNotContainsStringIgnoringCase( '<script', $decoded );
+	}
+
+	/** A non-SVG payload with an .svg extension must be rejected. */
+	public function test_non_svg_content_is_rejected() {
+		$file = $this->make_upload( 'fake.svg', 'this is definitely not an svg file at all' );
+
+		$res = $this->run_prefilter( $file );
+
+		$this->assertNotEmpty( $res['error'] ?? '', 'non-SVG content in a .svg must set an error' );
+	}
+
+	/** A non-SVG extension is ignored entirely (returned untouched, no error). */
+	public function test_non_svg_extension_passes_through_untouched() {
+		$file = $this->make_upload( 'photo.png', 'PNGDATA' );
+
+		$res = $this->run_prefilter( $file );
+
+		$this->assertSame( '', (string) ( $res['error'] ?? '' ) );
+	}
+}

--- a/tests/phpunit/tests/test-upload-validation.php
+++ b/tests/phpunit/tests/test-upload-validation.php
@@ -63,7 +63,7 @@ class Test_Upload_Validation extends WP_UnitTestCase {
 
 		$res = $this->run_prefilter( $file );
 
-		$this->assertSame( '', (string) ( $res['error'] ?? '' ), 'valid SVG should not set an error' );
+		$this->assertEmpty( ( $res['error'] ?? '' ), 'valid SVG should not set an error' );
 		$cleaned = file_get_contents( $res['tmp_name'] );
 		$this->assertStringNotContainsStringIgnoringCase( '<script', $cleaned, 'script must be stripped on upload' );
 		$this->assertStringContainsString( '<rect', $cleaned, 'safe content should survive' );
@@ -79,7 +79,7 @@ class Test_Upload_Validation extends WP_UnitTestCase {
 
 		$res = $this->run_prefilter( $file );
 
-		$this->assertSame( '', (string) ( $res['error'] ?? '' ), 'plaintext .svgz that is valid SVG should be accepted (then sanitized)' );
+		$this->assertEmpty( ( $res['error'] ?? '' ), 'plaintext .svgz that is valid SVG should be accepted (then sanitized)' );
 		$cleaned = file_get_contents( $res['tmp_name'] );
 		$this->assertStringNotContainsStringIgnoringCase( '<script', $cleaned, '.svgz must not bypass sanitization' );
 	}
@@ -91,7 +91,7 @@ class Test_Upload_Validation extends WP_UnitTestCase {
 
 		$res = $this->run_prefilter( $file );
 
-		$this->assertSame( '', (string) ( $res['error'] ?? '' ) );
+		$this->assertEmpty( ( $res['error'] ?? '' ) );
 		$out = file_get_contents( $res['tmp_name'] );
 		$decoded = ( substr( $out, 0, 3 ) === "\x1f\x8b\x08" ) ? gzdecode( $out ) : $out;
 		$this->assertStringNotContainsStringIgnoringCase( '<script', $decoded );
@@ -112,6 +112,6 @@ class Test_Upload_Validation extends WP_UnitTestCase {
 
 		$res = $this->run_prefilter( $file );
 
-		$this->assertSame( '', (string) ( $res['error'] ?? '' ) );
+		$this->assertEmpty( ( $res['error'] ?? '' ) );
 	}
 }

--- a/tests/sanitizer/run.php
+++ b/tests/sanitizer/run.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Standalone sanitizer regression runner.
+ *
+ * Exercises the plugin's REAL sanitization engine — the vendored
+ * enshrined/svg-sanitize library configured with SVG Support's own
+ * bodhi_svg_tags / bodhi_svg_attributes whitelists and removeRemoteReferences,
+ * exactly as bodhi_svgs_sanitize() sets it up — against the fixture corpus.
+ *
+ * It needs no WordPress and no Docker: it shims the handful of WP functions the
+ * whitelist classes call, so it runs anywhere PHP is available (locally and in
+ * CI) as a fast first gate. WordPress-dependent behavior (upload prefilter,
+ * roles, nonce, plaintext-.svgz validation, settings) is covered by the
+ * WP-PHPUnit suite in tests/phpunit.
+ *
+ * Usage:  php tests/sanitizer/run.php
+ * Exit:   0 all assertions passed, 1 any failure.
+ */
+
+error_reporting( E_ALL & ~E_DEPRECATED );
+
+$PLUGIN_ROOT = dirname( __DIR__, 2 );
+
+// --- Minimal WordPress shims (only what the whitelist classes touch) ---------
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', $PLUGIN_ROOT . '/' );
+}
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value ) { return $value; }
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action() { return true; }
+}
+if ( ! function_exists( 'current_user_can' ) ) {
+	function current_user_can() { return true; }
+}
+if ( ! function_exists( 'esc_html__' ) ) {
+	function esc_html__( $text ) { return $text; }
+}
+
+// --- Load the real sanitizer + the plugin's actual whitelists ----------------
+require $PLUGIN_ROOT . '/vendor/autoload.php';
+require $PLUGIN_ROOT . '/includes/svg-tags.php';
+require $PLUGIN_ROOT . '/includes/svg-attributes.php';
+
+use enshrined\svgSanitize\Sanitizer;
+
+/**
+ * Mirror of bodhi_svgs_sanitize()'s core configuration + gzip round-trip,
+ * operating on a string instead of a file so it is pure and testable.
+ */
+function svgs_test_sanitize_string( $dirty, $minify = false ) {
+	$sanitizer = new Sanitizer();
+	$sanitizer->setAllowedTags( new bodhi_svg_tags() );
+	$sanitizer->setAllowedAttrs( new bodhi_svg_attributes() );
+	$sanitizer->removeRemoteReferences( true );
+	if ( $minify ) {
+		$sanitizer->minify( true );
+	}
+
+	$is_zipped = ( strncmp( $dirty, "\x1f\x8b\x08", 3 ) === 0 );
+	if ( $is_zipped ) {
+		$dirty = gzdecode( $dirty );
+		if ( $dirty === false ) {
+			return false;
+		}
+	}
+
+	$clean = $sanitizer->sanitize( $dirty );
+	if ( $clean === false ) {
+		return false;
+	}
+
+	if ( $is_zipped ) {
+		$clean = gzencode( $clean );
+	}
+
+	return $clean;
+}
+
+// --- Tiny assertion harness --------------------------------------------------
+$GLOBALS['__pass'] = 0;
+$GLOBALS['__fail'] = 0;
+$GLOBALS['__failures'] = array();
+
+function check( $label, $cond ) {
+	if ( $cond ) {
+		$GLOBALS['__pass']++;
+	} else {
+		$GLOBALS['__fail']++;
+		$GLOBALS['__failures'][] = $label;
+		fwrite( STDOUT, "  \033[31mFAIL\033[0m  $label\n" );
+	}
+}
+
+function section( $name ) {
+	fwrite( STDOUT, "\n\033[1m$name\033[0m\n" );
+}
+
+function note( $msg ) {
+	fwrite( STDOUT, "  \033[33mNOTE\033[0m  $msg\n" );
+}
+
+$benign_dir    = "$PLUGIN_ROOT/tests/fixtures/benign";
+$malicious_dir = "$PLUGIN_ROOT/tests/fixtures/malicious";
+
+// --- Benign: must survive, stay valid SVG, keep their signature content ------
+section( 'Benign fixtures survive sanitization' );
+
+$benign_expect = array(
+	'simple-icon.svg'           => array( '<path', 'M12 2' ),
+	'viewbox-no-dimensions.svg' => array( '<circle', 'viewBox' ),
+	'nested-svg.svg'            => array( '<rect', '<path' ),
+	'use-symbol.svg'            => array( '<use', '<symbol' ),
+	'embedded-style.svg'        => array( '<style', 'fill:#9333ea' ),
+	'gradient.svg'              => array( 'linearGradient', 'url(#g)' ),
+	'title-desc-a11y.svg'       => array( '<title', '<desc', 'aria-labelledby' ),
+	'currentcolor.svg'          => array( 'currentColor' ),
+	'text-element.svg'          => array( '<text', 'SVG OK' ),
+	// NOTE: animate-smil.svg deliberately omitted here — see the
+	// "Documented current behavior" section below. The sanitizer strips SMIL
+	// animation elements, so the shape it keeps is the <circle>, not <animate>.
+	'animate-smil.svg'          => array( '<circle' ),
+);
+
+foreach ( $benign_expect as $file => $needles ) {
+	$dirty = file_get_contents( "$benign_dir/$file" );
+	$clean = svgs_test_sanitize_string( $dirty );
+	check( "$file — sanitizes without error", $clean !== false );
+	check( "$file — remains an <svg>", $clean !== false && stripos( $clean, '<svg' ) !== false );
+	foreach ( $needles as $needle ) {
+		check( "$file — keeps \"$needle\"", $clean !== false && strpos( $clean, $needle ) !== false );
+	}
+}
+
+// --- Malicious: dangerous payload must be gone; still returns valid SVG -------
+section( 'Malicious fixtures are neutralized' );
+
+// For each fixture, the case-insensitive substrings that MUST NOT survive.
+$malicious_forbid = array(
+	'script-tag.svg'                 => array( '<script', "alert('xss-script-tag')" ),
+	'onload-attr.svg'                => array( 'onload' ),
+	'onclick-attr.svg'               => array( 'onclick' ),
+	'anchor-javascript-href.svg'     => array( 'javascript:' ),
+	'xlink-javascript-href.svg'      => array( 'javascript:' ),
+	'mixedcase-xlink-href.svg'       => array( 'javascript:' ),
+	'foreignobject-script.svg'       => array( '<script', 'foreignobject' ),
+	// external-image-href.svg is intentionally NOT here — remote <image href>
+	// currently survives (see "Documented current behavior" below).
+	'external-use-href.svg'          => array( 'evil.example.com' ),
+	'xxe-entity.svg'                 => array( 'file:///', '<!entity', 'system' ),
+	'billion-laughs.svg'             => array( '<!entity' ),
+	'animate-values-javascript.svg'  => array( 'javascript:' ),
+	'handler-element.svg'            => array( '<handler' ),
+	'set-onbegin.svg'                => array( 'onbegin' ),
+);
+
+foreach ( $malicious_forbid as $file => $forbidden ) {
+	$dirty = file_get_contents( "$malicious_dir/$file" );
+	$clean = svgs_test_sanitize_string( $dirty );
+	// The sanitizer should neutralize, not reject outright — a returned string
+	// that still parses as SVG is the expected shape (false is also acceptable
+	// for the entity-expansion cases as long as nothing dangerous leaks).
+	if ( $clean === false ) {
+		check( "$file — rejected outright (acceptable)", true );
+		continue;
+	}
+	$hay = strtolower( $clean );
+	foreach ( $forbidden as $bad ) {
+		check( "$file — strips \"$bad\"", strpos( $hay, strtolower( $bad ) ) === false );
+	}
+	// Bound output so an entity expansion can't quietly balloon.
+	check( "$file — output stays bounded (<64KB)", strlen( $clean ) < 65536 );
+}
+
+// --- Documented current behavior (lock it so future drift is caught) ---------
+// These assertions encode what the sanitizer does TODAY, including two known
+// limitations. They are green on purpose: if a dependency bump changes either
+// behavior, these flip to red and we find out on the next run rather than in
+// production. Both are flagged for the v3.0 server-side engine.
+section( 'Documented current behavior (baseline lock)' );
+
+// 1. SMIL animation elements are not in the sanitizer whitelist, so they are
+//    removed on upload. Locking this so a dependency bump that changes it is
+//    caught here rather than in production.
+$smil = svgs_test_sanitize_string( file_get_contents( "$benign_dir/animate-smil.svg" ) );
+check( 'SMIL <animate> is stripped by the sanitizer', $smil !== false && stripos( $smil, '<animate' ) === false );
+check( 'SMIL <set> is stripped by the sanitizer', $smil !== false && stripos( $smil, '<set' ) === false );
+check( 'shape around the SMIL survives (<circle>)', $smil !== false && stripos( $smil, '<circle' ) !== false );
+note( 'SMIL animation elements are removed on upload by the sanitizer whitelist.' );
+
+// 2. Remote <image href> passes through (enshrined strips remote <use> but not
+//    remote <image>). Privacy/tracking vector when rendered inline. Longstanding
+//    (not a 2.6.0 regression); v3.0 server-side engine should strip/block it.
+$img = svgs_test_sanitize_string( file_get_contents( "$malicious_dir/external-image-href.svg" ) );
+check( 'remote <image href> currently survives (known limitation)', $img !== false && stripos( $img, 'evil.example.com' ) !== false );
+check( 'remote <use href> IS stripped (for contrast)', stripos( (string) svgs_test_sanitize_string( file_get_contents( "$malicious_dir/external-use-href.svg" ) ), 'evil.example.com' ) === false );
+note( 'Remote <image href> is not stripped by enshrined — address in the v3.0 server-side engine.' );
+
+// --- .svgz gzip round-trip: decode, clean, re-encode -------------------------
+section( 'Gzipped .svgz round-trip' );
+
+$plain_dirty = file_get_contents( "$malicious_dir/script-tag.svg" );
+$gz_dirty    = gzencode( $plain_dirty );
+check( 'input is gzip-framed', strncmp( $gz_dirty, "\x1f\x8b\x08", 3 ) === 0 );
+
+$gz_clean = svgs_test_sanitize_string( $gz_dirty );
+check( '.svgz — sanitizes without error', $gz_clean !== false );
+check( '.svgz — output is still gzip-framed', $gz_clean !== false && strncmp( $gz_clean, "\x1f\x8b\x08", 3 ) === 0 );
+$decoded = $gz_clean !== false ? gzdecode( $gz_clean ) : '';
+check( '.svgz — decoded payload is clean', strpos( strtolower( (string) $decoded ), '<script' ) === false );
+check( '.svgz — decoded payload keeps the safe <path>', strpos( (string) $decoded, '<path' ) !== false );
+
+// --- Public filter extension points still work -------------------------------
+section( 'Public API: svg_allowed_tags / svg_allowed_attributes exist' );
+check( 'bodhi_svg_tags::getTags returns a non-empty array', is_array( bodhi_svg_tags::getTags() ) && count( bodhi_svg_tags::getTags() ) > 0 );
+check( 'bodhi_svg_attributes::getAttributes returns a non-empty array', is_array( bodhi_svg_attributes::getAttributes() ) && count( bodhi_svg_attributes::getAttributes() ) > 0 );
+
+// --- Summary -----------------------------------------------------------------
+$pass = $GLOBALS['__pass'];
+$fail = $GLOBALS['__fail'];
+fwrite( STDOUT, "\n" );
+if ( $fail === 0 ) {
+	fwrite( STDOUT, "\033[32m✓ ALL PASSED\033[0m — $pass assertions\n" );
+	exit( 0 );
+}
+fwrite( STDOUT, "\033[31m✗ $fail FAILED\033[0m / " . ( $pass + $fail ) . " assertions\n" );
+exit( 1 );


### PR DESCRIPTION
Builds the automated regression suite that enforces the v3.0 compatibility covenant — the green baseline the rewrite's legacy paths get diffed against. No plugin runtime code changes; this is tests + CI only.

## What's here
- **Standalone sanitizer runner** (`tests/sanitizer/run.php`) — no Docker: exercises the real enshrined library with the plugin's own whitelists against the fixture corpus. 80 assertions.
- **WP-PHPUnit suite** (`tests/phpunit/`) — settings-sanitize contract (all 14 option keys, defaults, legacy string coercion), file-based sanitizer + gzip .svgz round-trip, upload prefilter incl. the .svgz XSS regression. 24 tests / 177 assertions.
- **Playwright e2e** (`tests/e2e/`) — redesigned settings screen: Advanced Mode live reveal, css_target autosave + persistence, classic no-JS fallback form.
- **CI** (`tests.yml`) — standalone sanitizer + wp-env PHPUnit matrix (PHP 7.4 floor, 8.2) + wp-env Playwright. All green.
- Excludes tests/ + dev config from the wp.org build (.distignore) and from Plugin Check (CI + local hook).

## Two behaviors locked as baseline (see commits)
- SMIL animation elements are stripped on upload (sanitizer whitelist).
- Remote `<image href>` currently passes through (longstanding enshrined limitation) while remote `<use>` is stripped.

## Notes
- PHP 8.4 leg deferred until a PHPUnit 10/11 bump (9.6 turns 8.4 deprecations into failures).
- No option keys, defaults, or runtime behavior changed.