### PR TITLE
2.6.1: fix WP-CLI upload fatal (sanitizer global scope)

### DIFF
--- a/functions/attachment.php
+++ b/functions/attachment.php
@@ -209,7 +209,7 @@ add_filter( 'wp_generate_attachment_metadata', 'bodhi_svgs_generate_svg_attachme
  */
 function bodhi_svgs_sanitize( $file ){
 
-	global $sanitizer;
+	$sanitizer = bodhi_svgs_sanitizer();
 
 	$sanitizer->setAllowedTags( new bodhi_svg_tags() );
 	$sanitizer->setAllowedAttrs( new bodhi_svg_attributes() );
@@ -270,10 +270,9 @@ function bodhi_svgs_sanitize( $file ){
 function bodhi_svgs_minify() {
 
 	global $bodhi_svgs_options;
-	global $sanitizer;
 
 	if ( !empty($bodhi_svgs_options['minify_svg']) && $bodhi_svgs_options['minify_svg'] === 'on' ) {
-		$sanitizer->minify(true);
+		bodhi_svgs_sanitizer()->minify(true);
 	}
 
 }

--- a/readme.txt
+++ b/readme.txt
@@ -151,6 +151,10 @@ You need to add the mime type for svg and svgz to: "MLA Settings > Media Library
 
 == Changelog ==
 
+= 2.6.1 =
+* **Fixed**:
+    - Fatal error when uploading SVGs through WP-CLI (`wp media import`, migration and hosting tooling) — the sanitizer instance never reached global scope in CLI contexts. No security impact: affected uploads crashed rather than skipping sanitization (failed closed). The sanitizer is now resolved through a defensive accessor, with regression tests covering the CLI loading context. Props to the community reporter.
+
 = 2.6.0 =
 * **New Features**:
     - Completely redesigned settings screen with the new SVG Support brand — cleaner panels, real toggle switches, role picker chips, and a live code sample
@@ -535,6 +539,9 @@ You need to add the mime type for svg and svgz to: "MLA Settings > Media Library
 
 
 == Upgrade Notice ==
+
+= 2.6.1 =
+Fixes a fatal error on SVG uploads via WP-CLI (wp media import and similar tooling). Tiny, safe update — no settings or behavior changes.
 
 = 2.6.0 =
 Completely redesigned settings screen with auto-save and instant Advanced Mode reveal. No settings or behavior changes — everything keeps working exactly as before. Also removes ~1,000 lines of third-party JS and fixes asset cache-busting on updates.

--- a/readme.txt
+++ b/readme.txt
@@ -153,7 +153,7 @@ You need to add the mime type for svg and svgz to: "MLA Settings > Media Library
 
 = 2.6.1 =
 * **Fixed**:
-    - Fatal error when uploading SVGs through WP-CLI (`wp media import`, migration and hosting tooling) — the sanitizer instance never reached global scope in CLI contexts. No security impact: affected uploads crashed rather than skipping sanitization (failed closed). The sanitizer is now resolved through a defensive accessor, with regression tests covering the CLI loading context. Props to the community reporter.
+    - Fatal error when uploading SVGs through WP-CLI (`wp media import`, migration and hosting tooling) — the sanitizer instance never reached global scope in CLI contexts. No security impact: affected uploads crashed rather than skipping sanitization (failed closed). The sanitizer is now resolved through a defensive accessor, with regression tests covering the CLI loading context. Props to Cal from Toolshed for the excellent report.
 
 = 2.6.0 =
 * **New Features**:

--- a/svg-support.php
+++ b/svg-support.php
@@ -3,7 +3,7 @@
 Plugin Name: 	SVG Support
 Plugin URI:		http://wordpress.org/plugins/svg-support/
 Description: 	Upload SVG files to the Media Library and render SVG files inline for direct styling/animation of an SVG's internal elements using CSS/JS.
-Version: 		2.6.0
+Version: 		2.6.1
 Author URI: 	https://benbodhi.com
 Text Domain: 	svg-support
 Domain Path:	/languages
@@ -48,8 +48,29 @@ include( BODHI_SVGS_PLUGIN_PATH . 'vendor/autoload.php' );
 // interfaces to enable custom whitelisting of svg tags and attributes
 include( BODHI_SVGS_PLUGIN_PATH . 'includes/svg-tags.php' );
 include( BODHI_SVGS_PLUGIN_PATH . 'includes/svg-attributes.php' );
-// initialize sanitizer
+// initialize sanitizer — explicitly in the global scope: WP-CLI includes
+// wp-settings.php from inside a method, so a bare top-level assignment in a
+// plugin file never reaches global scope there, and every sanitize-on-upload
+// (wp media import, migrations, hosting tooling) fataled on a null sanitizer.
+global $sanitizer;
 $sanitizer = new Sanitizer();
+
+/**
+ * The shared sanitizer instance, rebuilt defensively if the global is missing
+ * in whatever loading context we find ourselves in. All consumers go through
+ * this instead of trusting `global $sanitizer` directly.
+ *
+ * @return \enshrined\svgSanitize\Sanitizer
+ */
+function bodhi_svgs_sanitizer() {
+	global $sanitizer;
+
+	if ( ! $sanitizer instanceof Sanitizer ) {
+		$sanitizer = new Sanitizer();
+	}
+
+	return $sanitizer;
+}
 
 /**
  * Includes - keeping it modular

--- a/tests/phpunit/tests/test-sanitizer-scope.php
+++ b/tests/phpunit/tests/test-sanitizer-scope.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Regression: the sanitizer must survive loading contexts where plugin
+ * file-scope variables never reach global scope (WP-CLI includes
+ * wp-settings.php from inside a method). Reported against 2.6.0 as a fatal
+ * on `wp media import` — bodhi_svgs_sanitizer() rebuilds the instance when
+ * the global is missing, and consumers go through it.
+ *
+ * @group sanitize
+ * @group cli-scope
+ */
+class Test_Sanitizer_Scope extends WP_UnitTestCase {
+
+	/** @var string */
+	private $work;
+
+	public function set_up() {
+		parent::set_up();
+		$this->work = wp_tempnam( 'svgs-scope' );
+	}
+
+	public function tear_down() {
+		if ( $this->work && file_exists( $this->work ) ) {
+			unlink( $this->work );
+		}
+		// Restore the shared instance for other tests.
+		$GLOBALS['sanitizer'] = new \enshrined\svgSanitize\Sanitizer();
+		parent::tear_down();
+	}
+
+	private function fixture( $name ) {
+		return dirname( __DIR__, 2 ) . '/fixtures/' . $name;
+	}
+
+	public function test_sanitize_works_without_the_global() {
+		unset( $GLOBALS['sanitizer'] );
+
+		copy( $this->fixture( 'malicious/onload-attr.svg' ), $this->work );
+		$result = bodhi_svgs_sanitize( $this->work );
+
+		$this->assertNotFalse( $result, 'sanitize must not fail when the global sanitizer is missing (CLI scope)' );
+		$clean = file_get_contents( $this->work );
+		$this->assertStringNotContainsString( 'onload', $clean, 'the rebuilt sanitizer must still strip event handlers' );
+	}
+
+	public function test_sanitize_strips_scripts_without_the_global() {
+		unset( $GLOBALS['sanitizer'] );
+
+		copy( $this->fixture( 'malicious/foreignobject-script.svg' ), $this->work );
+		bodhi_svgs_sanitize( $this->work );
+
+		$this->assertStringNotContainsString( '<script', file_get_contents( $this->work ), 'the rebuilt sanitizer must still strip script elements' );
+	}
+
+	public function test_minify_does_not_fatal_without_the_global() {
+		global $bodhi_svgs_options;
+		unset( $GLOBALS['sanitizer'] );
+		$bodhi_svgs_options['minify_svg'] = 'on';
+
+		bodhi_svgs_minify();
+
+		$this->assertInstanceOf( \enshrined\svgSanitize\Sanitizer::class, $GLOBALS['sanitizer'], 'minify must rebuild the shared instance instead of fataling' );
+
+		unset( $bodhi_svgs_options['minify_svg'] );
+	}
+}


### PR DESCRIPTION
## The report (community email) checks out completely

- Pristine wp.org 2.6.0 zip sha256 matches the reporter's: `a91399e3…74fd7ed8`
- Reproduced the exact fatal on a clean LocalWP site: `Call to a member function setAllowedTags() on null` at `functions/attachment.php:214` on `wp media import`
- Root cause confirmed: WP-CLI includes `wp-settings.php` inside a method, so the top-level `$sanitizer = new Sanitizer();` never reaches global scope. Browser/REST uploads are unaffected.
- **No security impact**: the bug fails closed — affected uploads crash, sanitization is never skipped.

## Why not the reporter's patch verbatim

Their lazy-init inside `bodhi_svgs_sanitize()` fixes one call site, but `bodhi_svgs_minify()` also consumes `global $sanitizer` and would still fatal with minification enabled. This PR fixes the root cause and hardens both consumers:

1. `global $sanitizer;` declared at init (same pattern `$bodhi_svgs_options` already uses)
2. New `bodhi_svgs_sanitizer()` accessor rebuilds the instance if the global is ever missing; both consumers go through it
3. Regression tests (`test-sanitizer-scope.php`): sanitize strips `onload`/`<script>` with the global unset; minify doesn't fatal

## Verified live (LocalWP, WP 7.0.2)

- Pristine 2.6.0: fatal reproduced ✗
- This build: `wp media import` succeeds ✓
- Hostile SVGs (`onload=`, `<script>` in foreignObject) imported via CLI: stored files contain **zero** occurrences of either ✓
- Version bumped to 2.6.1, changelog + upgrade notice added (stable tag is auto-set by the deploy workflow)